### PR TITLE
Add subtle diagonal swipe and visible correct overlay

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -581,6 +581,44 @@
         .try-again-button:hover {
             background-color: #d32f2f;
         }
+
+        /* Correct Answer Overlay */
+        #correct-overlay {
+            position: absolute;
+            top: 40%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            font-size: 3rem;
+            font-weight: bold;
+            color: #00ff99;
+            text-shadow: 2px 2px 5px rgba(0, 0, 0, 0.7);
+            z-index: 150; /* above headers */
+            display: none;
+            pointer-events: none;
+        }
+
+        .correct-show {
+            display: block;
+            animation: correctFlash 1s forwards;
+        }
+
+        @keyframes correctFlash {
+            0% { opacity: 0; transform: translate(-50%, -50%) scale(0.5); }
+            50% { opacity: 1; transform: translate(-50%, -50%) scale(1.2); }
+            100% { opacity: 0; transform: translate(-50%, -50%) scale(1); }
+        }
+
+        /* Swipe transition for next question */
+        .swipe-transition {
+            animation: swipeTransition 0.7s ease-in-out forwards;
+        }
+
+        @keyframes swipeTransition {
+            0% { transform: translate(0, 0); }
+            45% { transform: translate(25%, -25%); }
+            55% { transform: translate(-25%, 25%); }
+            100% { transform: translate(0, 0); }
+        }
         
         /* Loading */
         #loading {

--- a/index.html
+++ b/index.html
@@ -58,6 +58,9 @@
             <img id="character-back" src="" alt="Explorer from behind" class="character-back">
             
             <img id="demon" src="assets/images/demon_wo_bg.png" alt="Demon" class="demon">
+
+            <!-- Correct Answer Overlay -->
+            <div id="correct-overlay">Correct!</div>
             
             <div class="road-choices">
                 <button id="left-choice" class="left-road-choice" onclick="selectAnswer('left')">

--- a/js/QuizLogic.js
+++ b/js/QuizLogic.js
@@ -20,10 +20,15 @@
         };
         
         // Local storage key for scores
-        const SCORES_STORAGE_KEY = 'genai_jungle_quest_scores';
+const SCORES_STORAGE_KEY = 'genai_jungle_quest_scores';
+
+        // Background images for each question (using placeholders for now)
+        const backgroundImagesDesktop = new Array(15).fill('assets/images/jungle_main_2_roads_16_9.png');
+        const backgroundImagesMobile = new Array(15).fill('assets/images/jungle_main_2_roads_mobile.png');
         
         // Audio elements
         let correctSound, wrongSound, winnerSound;
+        let desktopBg, mobileBg, correctOverlay;
         
         // DOM elements
         let loadingScreen, characterSelection, gameScreen, resultScreen, incorrectPopup, formModal;
@@ -41,6 +46,9 @@
                 resultScreen = document.getElementById('result-screen');
                 incorrectPopup = document.getElementById('incorrect-popup');
                 formModal = document.getElementById('form-modal');
+                desktopBg = document.querySelector('.jungle-background-desktop');
+                mobileBg = document.querySelector('.jungle-background-mobile');
+                correctOverlay = document.getElementById('correct-overlay');
                 
                 console.log('DOM elements initialized successfully');
             } catch (error) {
@@ -169,6 +177,10 @@
             
             // Randomly decide which road (left or right) will have the fact
             gameState.factIsLeft = Math.random() > 0.5;
+
+            // Update background images
+            if (desktopBg) desktopBg.src = backgroundImagesDesktop[gameState.currentQuestionIndex % backgroundImagesDesktop.length];
+            if (mobileBg) mobileBg.src = backgroundImagesMobile[gameState.currentQuestionIndex % backgroundImagesMobile.length];
             
             // Set question texts
             document.getElementById('left-text').textContent = gameState.factIsLeft ? question.fact : question.myth;
@@ -186,25 +198,28 @@
             
             if (isCorrect) {
                 if (correctSound) correctSound.play();
-                
+
                 // Calculate score based on time and attempts
                 const timeTaken = Date.now() - gameState.startTime;
                 gameState.score += calculateScore(gameState.attempts, timeTaken);
-                
+
                 // Reset attempts and update questions answered
                 gameState.attempts = 0;
                 gameState.questionsAnswered++;
-                
-                // Check if game is won
-                if (gameState.questionsAnswered >= gameState.questions.length) {
-                    gameState.endTime = Date.now();
-                    gameWon();
-                } else {
-                    // Move to next question
-                    gameState.currentQuestionIndex++;
-                    gameState.startTime = Date.now();
-                    loadQuestion();
-                }
+
+                showCorrectAnimation();
+                setTimeout(() => {
+                    swipeTransition(() => {
+                        if (gameState.questionsAnswered >= gameState.questions.length) {
+                            gameState.endTime = Date.now();
+                            gameWon();
+                        } else {
+                            gameState.currentQuestionIndex++;
+                            gameState.startTime = Date.now();
+                            loadQuestion();
+                        }
+                    });
+                }, 150);
             } else {
                 if (wrongSound) wrongSound.play();
                 
@@ -254,6 +269,27 @@
         // Try again after incorrect answer
         function tryAgain() {
             if (incorrectPopup) incorrectPopup.style.display = 'none';
+        }
+
+        function showCorrectAnimation() {
+            if (correctOverlay) {
+                correctOverlay.classList.add('correct-show');
+                setTimeout(() => {
+                    correctOverlay.classList.remove('correct-show');
+                }, 800);
+            }
+        }
+
+        function swipeTransition(callback) {
+            if (gameScreen) {
+                gameScreen.classList.add('swipe-transition');
+                setTimeout(() => {
+                    gameScreen.classList.remove('swipe-transition');
+                    if (callback) callback();
+                }, 600);
+            } else if (callback) {
+                callback();
+            }
         }
         
         // Game over


### PR DESCRIPTION
## Summary
- use higher z-index for the correct answer overlay
- adjust the swipe animation to move diagonally and more subtly
- delay swipe start so the overlay is visible while transitioning

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68499f9bbca88326831b806343af7d83